### PR TITLE
chore: approve call more than once

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,7 @@ module.exports = function(api) {
     ],
     'plugins': [
       '@babel/plugin-proposal-export-default-from',
-      ['@babel/plugin-proposal-class-properties', { 'loose': false }],
+      ['@babel/plugin-proposal-class-properties', { 'loose': true }],
       'babel-plugin-transform-jsx-stylesheet',
       ['@babel/plugin-proposal-decorators', { 'legacy': true }],
     ],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-flow": "7.0.0",
     "@babel/preset-react": "7.0.0",
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "^23.6.0",

--- a/packages/useRouter/CHANGELOG.md
+++ b/packages/useRouter/CHANGELOG.md
@@ -1,0 +1,7 @@
+## CHANGELOG
+
+### v3.1.0
+
+- Chore: approve call `useRouter` more than once
+- Chore: support history v5
+- Chore: update `path-to-regexp` version

--- a/packages/useRouter/CHANGELOG.md
+++ b/packages/useRouter/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ### v3.1.0
 
-- Chore: approve call `useRouter` more than once
+- Feat: approve call `useRouter` more than once, because hmr will execute the same file more than once
 - Chore: support history v5
 - Chore: update `path-to-regexp` version

--- a/packages/useRouter/README.md
+++ b/packages/useRouter/README.md
@@ -284,3 +284,7 @@ The `location` object implements a subset of [the `window.location` interface](h
 - `location.hash` - The URL hash fragment
 
 For more information, see [history](https://www.npmjs.com/package/history)
+
+## Notice
+
+In most cases, we don't recommend using `useRouter` in multiple places on the page. Reason of this is the latter `routerConfig` will override the previous.

--- a/packages/useRouter/package.json
+++ b/packages/useRouter/package.json
@@ -1,9 +1,11 @@
 {
   "name": "rax-use-router",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Rax useRouter hook.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/raxjs/rax-hooks.git"
@@ -20,10 +22,10 @@
   },
   "devDependencies": {
     "driver-server": "^1.0.0",
-    "history": "^4.9.0",
+    "history": "^5.0.0",
     "rax": "^1.0.0"
   },
   "dependencies": {
-    "path-to-regexp": "^3.0.0"
+    "path-to-regexp": "^6.0.0"
   }
 }

--- a/packages/useRouter/src/index.js
+++ b/packages/useRouter/src/index.js
@@ -1,6 +1,6 @@
 // Inspired by react-router and universal-router
 import { useState, useLayoutEffect, createElement } from 'rax';
-import pathToRegexp from 'path-to-regexp';
+import { pathToRegexp } from 'path-to-regexp';
 
 const cache = {};
 function decodeParam(val) {
@@ -119,8 +119,6 @@ function matchRoute(route, baseUrl, pathname, parentParams) {
   };
 }
 
-let _initialized = false;
-let _routerConfig = null;
 const router = {
   history: null,
   handles: [],
@@ -189,37 +187,29 @@ function matchLocation({ pathname }) {
 function getInitialComponent(routerConfig) {
   let InitialComponent = [];
 
-  if (_routerConfig === null) {
-    if (typeof routerConfig === 'function') {
-      routerConfig = routerConfig();
+  if (process.env.NODE_ENV !== 'production') {
+    if (!routerConfig) {
+      throw new Error('Error: useRouter should have routerConfig, see: https://www.npmjs.com/package/rax-use-router.');
     }
-
-    if (process.env.NODE_ENV !== 'production') {
-      if (!routerConfig) {
-        throw new Error('Error: useRouter should have routerConfig, see: https://www.npmjs.com/package/rax-use-router.');
-      }
-      if (!routerConfig.history || !routerConfig.routes) {
-        throw new Error('Error: routerConfig should contain history and routes, see: https://www.npmjs.com/package/rax-use-router.');
-      }
+    if (!routerConfig.history || !routerConfig.routes) {
+      throw new Error('Error: routerConfig should contain history and routes, see: https://www.npmjs.com/package/rax-use-router.');
     }
-    _routerConfig = routerConfig;
   }
-  if (_routerConfig.InitialComponent) {
-    InitialComponent = _routerConfig.InitialComponent;
+  if (routerConfig.InitialComponent) {
+    InitialComponent = routerConfig.InitialComponent;
   }
-  router.history = _routerConfig.history;
+  router.history = routerConfig.history;
 
   return InitialComponent;
 }
 
 export function useRouter(routerConfig) {
+  routerConfig = typeof routerConfig === 'function' ? routerConfig() : routerConfig;
   const [component, setComponent] = useState(getInitialComponent(routerConfig));
 
   useLayoutEffect(() => {
-    if (_initialized) throw new Error('Error: useRouter can only be called once.');
-    _initialized = true;
-    const history = _routerConfig.history;
-    const routes = _routerConfig.routes;
+    const history = routerConfig.history;
+    const routes = routerConfig.routes;
 
     router.root = Array.isArray(routes) ? { routes } : routes;
 
@@ -228,12 +218,17 @@ export function useRouter(routerConfig) {
     });
 
     // Init path match
-    if (!_routerConfig.InitialComponent) {
+    if (!routerConfig.InitialComponent) {
       matchLocation(history.location);
     }
 
     const unlisten = history.listen((location, action) => {
-      matchLocation(location);
+      if (!action) {
+        // Support history v5
+        matchLocation(location.location);
+      } else {
+        matchLocation(location);
+      }
     });
 
     return () => {

--- a/packages/useRouter/src/index.js
+++ b/packages/useRouter/src/index.js
@@ -222,11 +222,13 @@ export function useRouter(routerConfig) {
       matchLocation(history.location);
     }
 
-    const unlisten = history.listen((location, action) => {
-      if (!action) {
+    const unlisten = history.listen((...args) => {
+      if (args.length === 1) {
         // Support history v5
-        matchLocation(location.location);
+        const { location } = args[0];
+        matchLocation(location);
       } else {
+        const [location] = args;
         matchLocation(location);
       }
     });


### PR DESCRIPTION
## Background

It will throw error with hmr.

## Change
- Chore: approve call `useRouter` more than once
- Chore: support history v5
- Chore: update `path-to-regexp` version